### PR TITLE
docs(bibliography): add sources for deep learning and ball bearing calculation

### DIFF
--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -1,23 +1,23 @@
+% Topic: Deep Learning
 @book{vasilev19,
   title     = {Python Deep Learning},
   subtitle  = {Exploring deep learning techniques and neural network architectures with PyTorch, Keras and TensorFlow},
   author    = {Vasilev, Ivan and Slater, Daniel and Spacagna, Gianmario and Roelants, Peter and Zocca, Valentino},
-  month     = {1},
   year      = {2019},
+  month     = {1},
   publisher = {Packt},
   edition   = {2},
   isbn      = {978-1-78934-846-0},
   url       = {https://books.google.de/books?id=ESKEDwAAQBAJ&lpg=PP1&ots=y4MuWVxnZR&dq=machine%20learning%20python%20pytorch&lr&hl=de&pg=PP1#v=onepage&q=machine%20learning%20python%20pytorch&f=false},
   keywords  = {machine learning; deep learning; neural networks; computer vision; convolutional neural networks; generative adversarial networks; variational autoencoders; recurrent neural networks; language models}
-  % github  = {https://github.com/ivan-vasilev/Python-Deep-Learning-SE}
 }
 
 @book{ketkar21,
   title     = {Deep Learning with Python},
   subtitle  = {A practical approach to building neural network models using PyTorch; Learn Best Practices of Deep Learning Models with PyTorch},
   author    = {Ketkar, Nikhil and Moolayil, Jojo},
-  month     = {4},
   year      = {2021},
+  month     = {4},
   publisher = {Apress Berkeley, CA},
   edition   = {2},
   isbn      = {978-1-4842-5364-9},
@@ -28,22 +28,48 @@
 @book{antiga20,
   title     = {Deep Learning with Pytorch},
   author    = {Antiga, Luca Pietro Giovanni and Stevens, Eli and Viehmann, Thomas},
-  month     = {8},
   year      = {2020},
+  month     = {8},
   publisher = {Manning Publications Co. LLC},
   isbn      = {978-1-6383-5407-9},
   url       = {https://ebookcentral.proquest.com/lib/mosbach-dhbw/detail.action?docID=6642896},
   keywords  = {pytorch; deep learning; pretrained networks; tensors; mechanics of learning; neural networks; object recognition; convolutions; image learning; deployment}
-  % book    = {https://isip.piconepress.com/courses/temple/ece_4822/resources/books/Deep-Learning-with-PyTorch.pdf}
 }
 
-@book{mueller20
+@book{mueller20,
   title     = {Deep Learning Kompakt Für Dummies},
   author    = {Mueller, John Paul and Massaron, Luca},
-  month     = {3},
   year      = {2020},
+  month     = {3},
   publisher = {John Wiley & Sons, Incorporated},
   isbn      = {978-3-5278-2597-4},
   url       = {http://ebookcentral.proquest.com/lib/mosbach-dhbw/detail.action?docID=6157425},
   keywords  = {deep learning; machine learning; python; matrices; linear regression; neural networks; convolutional networks; recurrent neural networks; image classification; language processing; music and art generation; generative adversarial networks; use cases; tools}
+}
+
+
+% Topic: Ball Bearings Calculation
+@book{wittel21,
+  title     = {Roloff/Matek Maschinenelemente},
+  subtitle  = {Normung, Berechnung, Gestaltung},
+  edition   = {25},
+  author    = {Wittel, Herbert and Spura, Christian and Jannasch, Dieter},
+  year      = {2021},
+  month     = {12},
+  publisher = {Springer Vieweg Wiesbaden},
+  isbn      = {978-3-658-34160-2},
+  url       = {https://doi.org/10.1007/978-3-658-34160-2},
+  keywords  = {movement screw; fatigue strength; ec 3; ec 9; eurocode 3; strength calculation; coupling; load spectrum; surface finish; fit; belt drive; screw; tolerance; rolling bearing; gear wheel; elastic spring; planetary gear; interference fit; din en iso 2553}
+}
+
+@book{wittel22,
+  title     = {Roloff/Matek Maschinenelemente Formelsammlung},
+  author    = {Wittel, Herbert and Spura, Christian and Jannasch, Dieter},
+  edition   = {16},
+  year      = {2022},
+  month     = {1},
+  publisher = {Springer Vieweg Wiesbaden},
+  isbn      = {978-3-658-34164-0},
+  url       = {https://doi.org/10.1007/978-3-658-34164-0},
+  keywords  = {axle; bolt connection; seal; elastic spring; plain bearing; detachable connection; standard number; fit; belt drive; locking element; spur gear; tolerance; shaft; rolling bearing; gear wheel; planetary gear; dynamic strength verification}
 }

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -41,7 +41,7 @@
   author    = {Mueller, John Paul and Massaron, Luca},
   year      = {2020},
   month     = {3},
-  publisher = {John Wiley & Sons, Incorporated},
+  publisher = {John Wiley \& Sons, Incorporated},
   isbn      = {978-3-5278-2597-4},
   url       = {http://ebookcentral.proquest.com/lib/mosbach-dhbw/detail.action?docID=6157425},
   keywords  = {deep learning; machine learning; python; matrices; linear regression; neural networks; convolutional networks; recurrent neural networks; image classification; language processing; music and art generation; generative adversarial networks; use cases; tools}

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -1,28 +1,49 @@
-@book{Gumm2011,
-  author    = {Gumm, Heinz-Peter AND Sommer, Manfred},
-  year      = {2011},
-  title     = {Einführung in die Informatik - },
-  edition   = {vollständig überarbeitete Auflage},
-  isbn      = {978-3-486-59711-0},
-  publisher = {Oldenbourg},
-  address   = {Deutschland}
+@book{vasilev19,
+  title     = {Python Deep Learning},
+  subtitle  = {Exploring deep learning techniques and neural network architectures with PyTorch, Keras and TensorFlow},
+  author    = {Vasilev, Ivan and Slater, Daniel and Spacagna, Gianmario and Roelants, Peter and Zocca, Valentino},
+  month     = {1},
+  year      = {2019},
+  publisher = {Packt},
+  edition   = {2},
+  isbn      = {978-1-78934-846-0},
+  url       = {https://books.google.de/books?id=ESKEDwAAQBAJ&lpg=PP1&ots=y4MuWVxnZR&dq=machine%20learning%20python%20pytorch&lr&hl=de&pg=PP1#v=onepage&q=machine%20learning%20python%20pytorch&f=false},
+  keywords  = {machine learning; deep learning; neural networks; computer vision; convolutional neural networks; generative adversarial networks; variational autoencoders; recurrent neural networks; language models}
+  % github  = {https://github.com/ivan-vasilev/Python-Deep-Learning-SE}
 }
 
-@ARTICLE{test,
-  author = {Matsutani, H. and Koibuchi, M. and Yamada, Y. and Hsu, D.F. and Amano,
-	H.},
-  title = {Fat H-Tree: A Cost-Efficient Tree-Based On-Chip Network},
-  journal = {Parallel and Distributed Systems, IEEE Transactions on},
-  year = {2009},
-  volume = {20},
-  pages = {1126-1141},
-  number = {8},
-  doi = {10.1109/TPDS.2008.233},
-  issn = {1045-9219},
-  keywords = {multiprocessor interconnection networks;network-on-chip;cell library;cost-efficient
-	tree-based on-chip network;deadlock-free routing;fat H-tree;microarchitecture
-	domain;network logic area;on-chip routers;process technology;tree
-	networks;tree-based interconnection network;Interconnection networks;Network
-	topology;On-chip interconnection networks;network topology;on-chip
-	networks;routing algorithm.;tree}
+@book{ketkar21,
+  title     = {Deep Learning with Python},
+  subtitle  = {A practical approach to building neural network models using PyTorch; Learn Best Practices of Deep Learning Models with PyTorch},
+  author    = {Ketkar, Nikhil and Moolayil, Jojo},
+  month     = {4},
+  year      = {2021},
+  publisher = {Apress Berkeley, CA},
+  edition   = {2},
+  isbn      = {978-1-4842-5364-9},
+  url       = {https://doi.org/10.1007/978-1-4842-5364-9},
+  keywords  = {machine learning; deep learning; neural networks; training; feed-forward neural networks; convolutional neural networks; recurrent neural networks}
+}
+
+@book{antiga20,
+  title     = {Deep Learning with Pytorch},
+  author    = {Antiga, Luca Pietro Giovanni and Stevens, Eli and Viehmann, Thomas},
+  month     = {8},
+  year      = {2020},
+  publisher = {Manning Publications Co. LLC},
+  isbn      = {978-1-6383-5407-9},
+  url       = {https://ebookcentral.proquest.com/lib/mosbach-dhbw/detail.action?docID=6642896},
+  keywords  = {pytorch; deep learning; pretrained networks; tensors; mechanics of learning; neural networks; object recognition; convolutions; image learning; deployment}
+  % book    = {https://isip.piconepress.com/courses/temple/ece_4822/resources/books/Deep-Learning-with-PyTorch.pdf}
+}
+
+@book{mueller20
+  title     = {Deep Learning Kompakt Für Dummies},
+  author    = {Mueller, John Paul and Massaron, Luca},
+  month     = {3},
+  year      = {2020},
+  publisher = {John Wiley & Sons, Incorporated},
+  isbn      = {978-3-5278-2597-4},
+  url       = {http://ebookcentral.proquest.com/lib/mosbach-dhbw/detail.action?docID=6157425},
+  keywords  = {deep learning; machine learning; python; matrices; linear regression; neural networks; convolutional networks; recurrent neural networks; image classification; language processing; music and art generation; generative adversarial networks; use cases; tools}
 }


### PR DESCRIPTION
So far I only added the literature in a .bib file as a .md file seems redundant. If you require an additional .md file, please let me know.

I assumed that the main topics of research are machine learning with PyTorch and ball bearing calculation. Please let me know if I missed anything or if there are other books you would recommend.

Closes #7 